### PR TITLE
Fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # playing-card-detection
 Generating a dataset of playing cards to train a neural net.
 
-The notebook **creating_playing_cards_dataset.ipynb** is a guide through the creation of a dataset of playing cards. The cards are labeled with their name (ex: "2c" for "2 of spades", "Kh" for King for hearts) and with the bounding boxes delimiting their printed corners.
+The notebook **creating_playing_cards_dataset.ipynb** is a guide through the creation of a dataset of playing cards. The cards are labeled with their name (ex: "2s" for "2 of spades", "Kh" for King for hearts) and with the bounding boxes delimiting their printed corners.
 
 This dataset can be used for the training of a neural net intended to detect/localize playing cards. It was used on the project __[Playing card detection with YOLO v3](https://youtu.be/pnntrewH0xg)__
 


### PR DESCRIPTION
I believe it should either read "2c" for "2 of clubs" or "2s" for "2 of spades" correct?